### PR TITLE
Add I2C General Call Commands

### DIFF
--- a/adafruit_mcp4728.py
+++ b/adafruit_mcp4728.py
@@ -36,6 +36,14 @@ _MCP4728_DEFAULT_ADDRESS = 0x60
 
 _MCP4728_CH_A_MULTI_EEPROM = 0x50
 
+_MCP4728_GENERAL_CALL_ADDRESS = 0x00
+
+_MCP4728_GENERAL_CALL_RESET_COMMAND = 0x06
+
+_MCP4728_GENERAL_CALL_WAKEUP_COMMAND = 0x09
+
+_MCP4728_GENERAL_CALL_SOFTWARE_UPDATE_COMMAND = 0x08
+
 
 class CV:
     """struct helper"""
@@ -226,6 +234,35 @@ class MCP4728:
         """Divides a given list into `chunk_size` sized chunks"""
         for i in range(0, len(big_list), chunk_size):
             yield big_list[i : i + chunk_size]
+
+    def _general_call(self, byte_command):
+        buffer_list = [_MCP4728_GENERAL_CALL_ADDRESS]
+        buffer_list += [byte_command]
+
+        buf = bytearray(buffer_list)
+
+        with self.i2c_device as i2c:
+            i2c.write(buf)
+
+    def reset(self):
+        """Internal Reset similar to a Power-on Reset (POR).
+        The contents of the EEPROM are loaded into each DAC input
+        and output registers immediately"""
+
+        self._general_call(_MCP4728_GENERAL_CALL_RESET_COMMAND)
+
+    def wakeup(self):
+        """Reset the Power-Down bits (PD1, PD0 = 0,0) and
+        Resumes Normal Operation mode"""
+
+        self._general_call(_MCP4728_GENERAL_CALL_WAKEUP_COMMAND)
+
+    def soft_update(self):
+        """Updates all DAC analog outputs (VOUT) at the same time."""
+
+        self._general_call(_MCP4728_GENERAL_CALL_SOFTWARE_UPDATE_COMMAND)
+
+    # TODO : general_call read address
 
 
 class Channel:

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -15,3 +15,12 @@ Example showing the way to work with Vref
 .. literalinclude:: ../examples/mcp4728_vref_example.py
     :caption: examples/examples/mcp4728_vref_example.py
     :linenos:
+
+General Call Example
+----------------------
+
+Example showing the way to work with General Calls
+
+.. literalinclude:: ../examples/mcp4728_generalcalltest.py
+    :caption: examples/examples/mcp4728_generalcalltest.py
+    :linenos:

--- a/examples/mcp4728_generalcalltest.py
+++ b/examples/mcp4728_generalcalltest.py
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2021 codenio (Aananth K)
+# SPDX-License-Identifier: MIT
+
+import board
+import adafruit_mcp4728
+
+i2c = board.I2C()  # uses board.SCL and board.SDA
+mcp4728 = adafruit_mcp4728.MCP4728(i2c)
+
+mcp4728.channel_a.value = 65535  # Voltage = VDD
+mcp4728.channel_b.value = int(65535 / 2)  # VDD/2
+mcp4728.channel_c.value = int(65535 / 4)  # VDD/4
+mcp4728.channel_d.value = 0  # 0V
+
+mcp4728.save_settings()  # save current voltages into EEPROM
+print("Settings Saved into EEPROM")
+
+input("Press Enter to modify the channel outputs...")
+
+mcp4728.channel_a.value = 0  # Modify output
+mcp4728.channel_b.value = 0  # Modify output
+mcp4728.channel_c.value = 0  # Modify output
+mcp4728.channel_d.value = 65535  # Modify output
+
+print("Channel Outputs Modified")
+
+input("Press Enter to invoke General Call Reset ...")
+
+mcp4728.reset()  # reset MCP4728


### PR DESCRIPTION
This PR address #9 , 
- Adds _general_call static methods for executing different general calls to MCP4728
- Adds reset, wakeup and soft_update general call static methods

Thoughts and Comments..?