### PR TITLE
Updating for MCP4728A4

### DIFF
--- a/adafruit_mcp4728.py
+++ b/adafruit_mcp4728.py
@@ -32,7 +32,9 @@ from struct import pack_into
 from time import sleep
 from adafruit_bus_device import i2c_device
 
-_MCP4728_DEFAULT_ADDRESS = 0x60
+MCP4728_DEFAULT_ADDRESS = 0x60
+
+MCP4728A4_DEFAULT_ADDRESS = 0x64
 
 _MCP4728_CH_A_MULTI_EEPROM = 0x50
 
@@ -115,7 +117,7 @@ class MCP4728:
 
     """
 
-    def __init__(self, i2c_bus, address: int = _MCP4728_DEFAULT_ADDRESS):
+    def __init__(self, i2c_bus, address: int = MCP4728_DEFAULT_ADDRESS):
 
         self.i2c_device = i2c_device.I2CDevice(i2c_bus, address)
 

--- a/adafruit_mcp4728.py
+++ b/adafruit_mcp4728.py
@@ -115,7 +115,7 @@ class MCP4728:
 
     """
 
-    def __init__(self, i2c_bus, address=_MCP4728_DEFAULT_ADDRESS):
+    def __init__(self, i2c_bus, address: int = _MCP4728_DEFAULT_ADDRESS):
 
         self.i2c_device = i2c_device.I2CDevice(i2c_bus, address)
 
@@ -289,7 +289,7 @@ class Channel:
     @property
     def normalized_value(self):
         """The DAC value as a floating point number in the range 0.0 to 1.0."""
-        return self.raw_value / (2**12 - 1)
+        return self.raw_value / (2 ** 12 - 1)
 
     @normalized_value.setter
     def normalized_value(self, value):
@@ -302,13 +302,13 @@ class Channel:
     def value(self):
         """The 16-bit scaled current value for the channel. Note that the MCP4728 is a 12-bit piece
         so quantization errors will occur"""
-        return self.normalized_value * (2**16 - 1)
+        return self.normalized_value * (2 ** 16 - 1)
 
     @value.setter
     def value(self, value):
-        if value < 0 or value > (2**16 - 1):
+        if value < 0 or value > (2 ** 16 - 1):
             raise AttributeError(
-                "`value` must be a 16-bit integer between 0 and %s" % (2**16 - 1)
+                "`value` must be a 16-bit integer between 0 and %s" % (2 ** 16 - 1)
             )
 
         # Scale from 16-bit to 12-bit value (quantization errors will occur!).
@@ -321,9 +321,9 @@ class Channel:
 
     @raw_value.setter
     def raw_value(self, value):
-        if value < 0 or value > (2**12 - 1):
+        if value < 0 or value > (2 ** 12 - 1):
             raise AttributeError(
-                "`raw_value` must be a 12-bit integer between 0 and %s" % (2**12 - 1)
+                "`raw_value` must be a 12-bit integer between 0 and %s" % (2 ** 12 - 1)
             )
         self._raw_value = value
         # disabling the protected access warning here because making it public would be

--- a/adafruit_mcp4728.py
+++ b/adafruit_mcp4728.py
@@ -289,7 +289,7 @@ class Channel:
     @property
     def normalized_value(self):
         """The DAC value as a floating point number in the range 0.0 to 1.0."""
-        return self.raw_value / (2 ** 12 - 1)
+        return self.raw_value / (2**12 - 1)
 
     @normalized_value.setter
     def normalized_value(self, value):
@@ -302,13 +302,13 @@ class Channel:
     def value(self):
         """The 16-bit scaled current value for the channel. Note that the MCP4728 is a 12-bit piece
         so quantization errors will occur"""
-        return self.normalized_value * (2 ** 16 - 1)
+        return self.normalized_value * (2**16 - 1)
 
     @value.setter
     def value(self, value):
-        if value < 0 or value > (2 ** 16 - 1):
+        if value < 0 or value > (2**16 - 1):
             raise AttributeError(
-                "`value` must be a 16-bit integer between 0 and %s" % (2 ** 16 - 1)
+                "`value` must be a 16-bit integer between 0 and %s" % (2**16 - 1)
             )
 
         # Scale from 16-bit to 12-bit value (quantization errors will occur!).
@@ -321,9 +321,9 @@ class Channel:
 
     @raw_value.setter
     def raw_value(self, value):
-        if value < 0 or value > (2 ** 12 - 1):
+        if value < 0 or value > (2**12 - 1):
             raise AttributeError(
-                "`raw_value` must be a 12-bit integer between 0 and %s" % (2 ** 12 - 1)
+                "`raw_value` must be a 12-bit integer between 0 and %s" % (2**12 - 1)
             )
         self._raw_value = value
         # disabling the protected access warning here because making it public would be

--- a/examples/mcp4728_generalcalltest.py
+++ b/examples/mcp4728_generalcalltest.py
@@ -1,48 +1,30 @@
 # SPDX-FileCopyrightText: 2021 codenio (Aananth K)
-
 # SPDX-License-Identifier: MIT
 
-
 import board
-
 import adafruit_mcp4728
 
-
 i2c = board.I2C()  # uses board.SCL and board.SDA
-
 mcp4728 = adafruit_mcp4728.MCP4728(i2c)
 
-
 mcp4728.channel_a.value = 65535  # Voltage = VDD
-
 mcp4728.channel_b.value = int(65535 / 2)  # VDD/2
-
 mcp4728.channel_c.value = int(65535 / 4)  # VDD/4
-
 mcp4728.channel_d.value = 0  # 0V
-
 
 mcp4728.save_settings()  # save current voltages into EEPROM
 
 print("Settings Saved into EEPROM")
 
-
 input("Press Enter to modify the channel outputs...")
 
-
 mcp4728.channel_a.value = 0  # Modify output
-
 mcp4728.channel_b.value = 0  # Modify output
-
 mcp4728.channel_c.value = 0  # Modify output
-
 mcp4728.channel_d.value = 65535  # Modify output
-
 
 print("Channel Outputs Modified")
 
-
 input("Press Enter to invoke General Call Reset ...")
-
 
 mcp4728.reset()  # reset MCP4728

--- a/examples/mcp4728_generalcalltest.py
+++ b/examples/mcp4728_generalcalltest.py
@@ -1,29 +1,48 @@
 # SPDX-FileCopyrightText: 2021 codenio (Aananth K)
+
 # SPDX-License-Identifier: MIT
 
+
 import board
+
 import adafruit_mcp4728
 
+
 i2c = board.I2C()  # uses board.SCL and board.SDA
+
 mcp4728 = adafruit_mcp4728.MCP4728(i2c)
 
+
 mcp4728.channel_a.value = 65535  # Voltage = VDD
+
 mcp4728.channel_b.value = int(65535 / 2)  # VDD/2
+
 mcp4728.channel_c.value = int(65535 / 4)  # VDD/4
+
 mcp4728.channel_d.value = 0  # 0V
 
+
 mcp4728.save_settings()  # save current voltages into EEPROM
+
 print("Settings Saved into EEPROM")
+
 
 input("Press Enter to modify the channel outputs...")
 
+
 mcp4728.channel_a.value = 0  # Modify output
+
 mcp4728.channel_b.value = 0  # Modify output
+
 mcp4728.channel_c.value = 0  # Modify output
+
 mcp4728.channel_d.value = 65535  # Modify output
+
 
 print("Channel Outputs Modified")
 
+
 input("Press Enter to invoke General Call Reset ...")
+
 
 mcp4728.reset()  # reset MCP4728

--- a/examples/mcp4728_simpletest.py
+++ b/examples/mcp4728_simpletest.py
@@ -4,8 +4,14 @@
 import board
 import adafruit_mcp4728
 
+MCP4728_DEFAULT_ADDRESS = 0x60
+MCP4728A4_DEFAULT_ADDRESS = 0x64
+
 i2c = board.I2C()  # uses board.SCL and board.SDA
-mcp4728 = adafruit_mcp4728.MCP4728(i2c)
+#  use for MCP4728 variant
+mcp4728 = adafruit_mcp4728.MCP4728(i2c, adafruit_mcp4728.MCP4728_DEFAULT_ADDRESS)
+#  use for MCP4728A4 variant
+#  mcp4728 = adafruit_mcp4728.MCP4728(i2c, adafruit_mcp4728.MCP4728A4_DEFAULT_ADDRESS)
 
 mcp4728.channel_a.value = 65535  # Voltage = VDD
 mcp4728.channel_b.value = int(65535 / 2)  # VDD/2


### PR DESCRIPTION
Updating library to be able to pass 0x64 I2C address for MCP4728A4 variant (see revision history on product copy: https://www.adafruit.com/product/4470).